### PR TITLE
Include PHP extensions in composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,8 @@
     ],
     "require": {
         "php": ">=7.0",
+        "ext-msgpack": "*",
+        "ext-zlib": "*",
         "silverstripe/versioned": "^1.1",
         "phptek/jsontext": "^2.0.0",
         "dcentrica/chainpoint-receiptviz-php": "^0.1",


### PR DESCRIPTION
Verifiable makes use of msgpack and zlib functions as per the README, and the code will throw an exception if either extension is not installed. Rather than depend on an exception, require the extensions to exist as a dependency.

I've left the exceptions in the codebase, as there's always the chance the module was installed outside of composer